### PR TITLE
Update for 2022

### DIFF
--- a/ACPIPatcherPkg/ACPIPatcher/ACPIPatcher.c
+++ b/ACPIPatcherPkg/ACPIPatcher/ACPIPatcher.c
@@ -163,5 +163,12 @@ AcpiPatcherEntryPoint (
   } else {
     SelectivePrint(L"ACPI patching successful\n");
   }
+
+  gFacp->Header.Checksum = 0;
+  gFacp->Header.Checksum = CalculateCheckSum8((UINT8*)gFacp, gFacp->Header.Length);
+
+  gXsdt->Checksum = 0;
+  gXsdt->Checksum = CalculateCheckSum8((UINT8*)gXsdt, gXsdt->Length);
+
   return Status;
 }

--- a/ACPIPatcherPkg/ACPIPatcher/ACPIPatcher.c
+++ b/ACPIPatcherPkg/ACPIPatcher/ACPIPatcher.c
@@ -11,7 +11,7 @@
 
 EFI_ACPI_2_0_ROOT_SYSTEM_DESCRIPTION_POINTER        *gRsdp      = NULL;
 EFI_ACPI_SDT_HEADER                                 *gXsdt      = NULL;
-EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE           *gFacp      = NULL;
+EFI_ACPI_6_4_FIXED_ACPI_DESCRIPTION_TABLE           *gFacp      = NULL;
 UINT64                                              gXsdtEnd    = 0;
 
 #ifndef DXE
@@ -80,8 +80,10 @@ PatchAcpi (
       }
       
       if(!StrnCmp(FileInfo->FileName, L"DSDT.aml", 9)) {
-          gFacp->Dsdt = (UINT32)FileBuffer;
+          gFacp->Dsdt = (UINT32)(UINTN)FileBuffer;
+          gFacp->XDsdt = (UINT64)FileBuffer;
           SelectivePrint(L"  New DSDT address: 0x%x\n", gFacp->Dsdt);
+          SelectivePrint(L"  New XDSDT address: 0x%llx\n", gFacp->XDsdt);
           continue;
       }
       
@@ -104,8 +106,8 @@ FindFacp()
   UINT64 *EntryPtr = (UINT64 *)(gXsdt + 1);
   for (UINTN Index = 0; Index < EntryCount; Index++, EntryPtr++) {
     Entry = (EFI_ACPI_SDT_HEADER *)((UINTN)(*EntryPtr));
-    if(Entry->Signature == EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE)
-      gFacp = (EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE *)Entry;
+    if(Entry->Signature == EFI_ACPI_6_4_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE)
+      gFacp = (EFI_ACPI_6_4_FIXED_ACPI_DESCRIPTION_TABLE *)Entry;
   }
   
   return EFI_SUCCESS;

--- a/ACPIPatcherPkg/ACPIPatcher/FsHelpers.c
+++ b/ACPIPatcherPkg/ACPIPatcher/FsHelpers.c
@@ -21,6 +21,7 @@
 #include <Guid/Gpt.h>
 
 #include "FsHelpers.h"
+EFI_LOADED_IMAGE_PROTOCOL           *gLoadedImage;
 
 /*++
  

--- a/ACPIPatcherPkg/ACPIPatcher/FsHelpers.c
+++ b/ACPIPatcherPkg/ACPIPatcher/FsHelpers.c
@@ -46,9 +46,13 @@ FsReadFileToBuffer (
   )
 {
     EFI_STATUS Status = EFI_SUCCESS;
-    *Buffer = AllocateZeroPool(BufferSize);
+    Status = gBS->AllocatePool(EfiRuntimeServicesData, BufferSize, Buffer);
+    if(Status != EFI_SUCCESS) {
+        return Status;
+    }
     Status = FileProtocol->Read(FileProtocol, &BufferSize, *Buffer);
     if(Status != EFI_SUCCESS) {
+        gBS->FreePool(Buffer);
         return Status;
     }
     

--- a/ACPIPatcherPkg/ACPIPatcher/FsHelpers.h
+++ b/ACPIPatcherPkg/ACPIPatcher/FsHelpers.h
@@ -12,8 +12,6 @@
 
 #include <Protocol/LoadedImage.h>
 
-EFI_LOADED_IMAGE_PROTOCOL           *gLoadedImage;
-
 /*++
  
  Routine Description:

--- a/ACPIPatcherPkg/ACPIPatcherPkg.dsc
+++ b/ACPIPatcherPkg/ACPIPatcherPkg.dsc
@@ -38,6 +38,7 @@
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
   UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+  RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
 
 [Components]
   ACPIPatcherPkg/ACPIPatcher/ACPIPatcher.inf


### PR DESCRIPTION
I could not think of a better title for this pull request, because it contains a number of different things.
I would be happy to split it up if that is better for your workflow; alternatively, it may be reasonable to "Rebase and Merge" so as to preserve the individual commits.

With these changes, I successfully replaced my DSDT and booted _Windows_ on the Framework Laptop.

Here's what's in it:

### ef15888: Switch AllocateZeroPool->AllocatePool; make sure to Free

This was a cleanup change that proved unnecessary to get ACPIPatcherPkg
to build; however, it removes an unnecessary buffer zeroing before the
file is read, and makes sure that we free the buffer in case of failure.


### 3c437a4: Fix duplicate definitions of gLoadedImage

Including a non-extern definition of `gLoadedImage` in FsHelpers.h
causes the compiler to emit a duplicate copy of `gLoadedImage` into
every translation unit that includes it. Since the only user of
`gLoadedImage` is _in FsHelpers.c_, it's reasonable to reduce the scope
of the variable.

If you'd like, we can reintroduce it as an `extern` in FsHelpers.h so
other parts of the code can access it.


### 5a06109: Add support for ACPI 6.4 and the 64-bit XDsdt offset

`XDsdt` contains the 64-bit address of the DSDT in memory.
64-bit-native Operating systems tend to prefer `XDsdt` over `Dsdt`,
especially because there is no guarantee that the DSDT was allocated in
low memory addressable by only 32 bits.

This change shouldn't cause any issues; after all, the header signature
for FACP 6.4 is identical to that of FACP 2.0; apart from the new use of
`XDsdt`, this change is mostly modernization.


### 9826bb8: Recalculate the Facp and Xsdt checksums

Linux complains about the checksums being wrong and helpfully "fixes"
them; Windows, on the other hand, fails to boot. This fixes that.


### 8cc22fb: Fix the build with modern edk2

Somebody needs a `RegisterFilterLib`, so I added one to your DSC.